### PR TITLE
fixing erroring

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "update": "npx npm-check-updates -u && npm install",
     "pr": "gt submit -p --ai",
     "lint": "eslint src/",
-    "package": "node scripts/assure-clean-vsix-directory.js && npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
+    "package": "node scripts/assure-clean-vsix-directory.mjs && npm run build && npx @vscode/vsce package --no-dependencies --skip-license -o vsix/",
     "publish:vsce": "npm run package && npx @vscode/vsce publish --packagePath vsix/*.vsix --pat $VSX_MARKETPLACE_ACCESS_TOKEN",
     "publish:ovsx": "npm run package && npx ovsx publish --packagePath vsix/*.vsix --pat $OVSX_ACCESS_TOKEN",
     "patch": "npm version patch",

--- a/scripts/assure-clean-vsix-directory.mjs
+++ b/scripts/assure-clean-vsix-directory.mjs
@@ -34,10 +34,3 @@ try {
   console.error(error)
   process.exit(1)
 }
-
-const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
-
-for(const file of vsixFiles) {
-  console.log(`Removing ${file}`)
-  unlinkSync(join(dir, file))
-}

--- a/scripts/assure-clean-vsix-directory.mjs
+++ b/scripts/assure-clean-vsix-directory.mjs
@@ -17,22 +17,27 @@ const dir = "vsix"
 try {
   if(existsSync(dir)) {
     const stats = statSync(dir)
-
     if(!stats.isDirectory()) {
       console.error(`'${dir}' is not a directory.`)
       process.exit(1)
     }
-  } else {
-    mkdirSync(dir)
 
     const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
-
     for(const file of vsixFiles) {
       console.log(`Removing ${file}`)
       unlinkSync(join(dir, file))
     }
+  } else {
+    mkdirSync(dir)
   }
 } catch(error) {
   console.error(error)
   process.exit(1)
+}
+
+const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
+
+for(const file of vsixFiles) {
+  console.log(`Removing ${file}`)
+  unlinkSync(join(dir, file))
 }

--- a/scripts/assure-clean-vsix-directory.mjs
+++ b/scripts/assure-clean-vsix-directory.mjs
@@ -6,15 +6,13 @@
  * built package.
  *
  * Usage:
- *   node scripts/clean-vsix.js [dir]
- *
- * If [dir] is omitted, defaults to "vsix/" relative to cwd.
+ *   node scripts/assure-clean-vsix-directory.mjs
  */
 
 import {existsSync, mkdirSync, readdirSync, statSync, unlinkSync} from "node:fs"
-import {join, resolve} from "node:path"
+import {join} from "node:path"
 
-const dir = resolve(process.argv[2] || "vsix")
+const dir = "vsix"
 
 try {
   if(existsSync(dir)) {
@@ -26,15 +24,15 @@ try {
     }
   } else {
     mkdirSync(dir)
+
+    const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
+
+    for(const file of vsixFiles) {
+      console.log(`Removing ${file}`)
+      unlinkSync(join(dir, file))
+    }
   }
 } catch(error) {
-  console.error(`Donde estan los gatos negros? upsidedownexclamationmarkEn los arboles! También, ${error.message}`)
+  console.error(error)
   process.exit(1)
-}
-
-const vsixFiles = readdirSync(dir).filter(f => f.endsWith(".vsix"))
-
-for(const file of vsixFiles) {
-  console.log(`Removing ${file}`)
-  unlinkSync(join(dir, file))
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the `assure-clean-vsix-directory` script by renaming the file from `.js` to `.mjs` and restructuring the cleanup logic so it runs in the correct branch.

- **File rename**: `assure-clean-vsix-directory.js` → `assure-clean-vsix-directory.mjs`, with the corresponding reference in `package.json` updated.
- **Bug fix**: The `.vsix` file removal loop was previously placed outside the `try/catch` block, meaning errors from `readdirSync`/`unlinkSync` were unhandled. It is now correctly placed inside the `if(existsSync(dir))` branch within the `try/catch`, so cleanup only runs when the directory already exists and any I/O errors are properly caught.
- **Simplified path handling**: Removed `resolve` and `process.argv[2]` support; the target directory is now hardcoded as `"vsix"`, which is appropriate given the script has a single well-known caller.
- **Improved error reporting**: Replaced the placeholder Spanish-language error message with `console.error(error)`, which surfaces the full error stack for easier debugging.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correct and the script now behaves as intended in all branches.

The cleanup logic is now correctly placed inside the if(existsSync(dir)) branch and wrapped in a try/catch. The new directory (else) path creates the dir but skips cleanup (correct, since it's brand new). The previously flagged concern is fully resolved with no new issues introduced.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["04-10-fixing\_erroring: 2026-04-10 23:43 ..."](https://github.com/gesslar/hex/commit/518d4021cfa6f43a090439b3fb21d5c73ad63a0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28071137)</sub>

<!-- /greptile_comment -->