### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
 
 jobs:
   Build:
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
 
       - run: npm install --omit=dev
 
@@ -30,7 +30,7 @@ jobs:
     uses: gesslar/Maint/.github/workflows/ReleaseOnly.yaml@main
     secrets: inherit
     with:
-      quality_check: "Quality"
-      artefacts: '["vsix"]'
+      quality_check: "Quality / Quality"
+      artefacts: "[\"vsix\"]"
     permissions:
       contents: write

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -30,7 +30,6 @@ jobs:
     uses: gesslar/Maint/.github/workflows/ReleaseOnly.yaml@main
     secrets: inherit
     with:
-      quality_check: "Quality / Quality"
       artefacts: "[\"vsix\"]"
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Release workflow with several minor changes: whitespace formatting for array literals, a Node.js version bump from `22` to `24`, removal of the `quality_check` input (previously discussed in this PR's thread), and a quoting style change for the `artefacts` JSON string from single-quoted to double-quoted with escaped inner quotes. All changes are functionally sound and the reusable workflow reference correctly targets `@main` in compliance with project conventions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are cosmetic and a straightforward Node.js version bump, with no new logic introduced.

All changes are intentional and well-scoped: whitespace normalization, Node 22→24 bump, and a JSON quoting style update. The reusable workflow is correctly pinned to @main. The quality_check removal was already discussed and acknowledged by the author. No regressions or correctness issues found.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["update"](https://github.com/gesslar/hex/commit/40ba2031d012d5f79f7ea985991bd6dabdc3d3ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28733851)</sub>

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->